### PR TITLE
Added library card search by initials 

### DIFF
--- a/flask-backend/searchLibraryComponents.py
+++ b/flask-backend/searchLibraryComponents.py
@@ -475,16 +475,31 @@ def get_library_by_artist(artist, library):
 
     return match_cards
 
+def is_match_by_initials(initials, text):
+    index = 0
+    for c in initials:
+        index = text.find(c, index)
+        if index == -1:
+            return False
+        index += 1
+    return True
 
-def get_library_by_name(name, library):
+def get_library_by_name(pattern, library):
     match_cards = []
+    remaining_cards = []
+    match_cards_by_initials = []
+    pattern = pattern.lower()
     for card in library:
-        name = name.lower()
-        if name in card['ASCII Name'].lower() or name in card['Name'].lower():
+        if pattern in card['ASCII Name'].lower() or pattern in card['Name'].lower():
             match_cards.append(card)
+        else:
+            remaining_cards.append(card)
 
-    return match_cards
+    for card in remaining_cards:
+        if is_match_by_initials(pattern, card['ASCII Name'].lower()) or is_match_by_initials(pattern, card['Name'].lower()):
+            match_cards_by_initials.append(card)
 
+    return match_cards + match_cards_by_initials # put "exact" matches first
 
 def get_library_by_id(id):
     with open("vteslib.json", "r") as library_file:

--- a/react-frontend/pages/components/DeckNewLibraryCard.jsx
+++ b/react-frontend/pages/components/DeckNewLibraryCard.jsx
@@ -30,7 +30,7 @@ function DeckNewLibraryCard(props) {
       body: JSON.stringify(input),
     };
 
-    if (inputValue.length > 2) {
+    if (inputValue.length > 2 || (inputValue.length == 2 && inputValue === inputValue.toUpperCase())) {
       return fetch(url, options).then((response) => response.json());
     } else {
       return null;


### PR DESCRIPTION
Eg. "gtu" for Govern the Unaligned, "pbm" for "Powerbase: Montreal", or "TV" for Target Vitals

The async search is now triggered by 3 characters, or 2 uppercase characters.

Remark: unit tests should be added. I don't know the python ecosystem well enough to set it up.

print(is_match_by_initials('gtu', 'govern the unaligned')) #returns true
print(is_match_by_initials('gover', 'govern the unaligned')) #returns true
print(is_match_by_initials('pbm', 'powerbase: montreal')) #returns true
print(is_match_by_initials('pbmont', 'powerbase: montreal')) #returns true
print(is_match_by_initials('dreamsof', 'dreams of the sphinx')) #returns true
print(is_match_by_initials('tv', 'target vitals')) #returns true
print(is_match_by_initials('pschi', 'praxis seizure: chicago')) #returns true

print(is_match_by_initials('ddrea', 'dreams of the sphinx')) #returns false