### PR TITLE
fix crash on missing playtest data in user response when logging in

### DIFF
--- a/frontend/src/context/AppContext.jsx
+++ b/frontend/src/context/AppContext.jsx
@@ -288,7 +288,7 @@ export const AppProvider = ({ children }) => {
       PRECON_DECKS,
     ])
       .then(([v, pt, cb, lb, nc, nl, lc, ll, pd, _lac, _lal, _lbc, _lbl, _ls]) => {
-        if (!v || CARD_VERSION > v || (userData?.[PLAYTEST][IS_PLAYTESTER] && !pt)) {
+        if (!v || CARD_VERSION > v || (userData?.[PLAYTEST]?.[IS_PLAYTESTER] && !pt)) {
           fetchAndSetCardBase(true, userData?.[PLAYTEST]?.secret);
         } else {
           limitedFullStore[CRYPT] = cb;
@@ -308,13 +308,18 @@ export const AppProvider = ({ children }) => {
   }, [userData]);
 
   useEffect(() => {
-    userServices.whoAmI().then((data) => {
-      if (data.success === false) {
+    userServices
+      .whoAmI()
+      .then((data) => {
+        if (data.success === false) {
+          setUserData(null);
+        } else {
+          setUserData(data);
+        }
+      })
+      .catch(() => {
         setUserData(null);
-      } else {
-        setUserData(data);
-      }
-    });
+      });
   }, []);
 
   const parseInventoryData = (inventoryData) => {
@@ -342,10 +347,10 @@ export const AppProvider = ({ children }) => {
       setPublicName(data.public_name);
       setEmail(data.email);
       setInventoryKey(data.inventory_key);
-      setIsPlaytester(data[PLAYTEST][IS_PLAYTESTER]);
-      setIsPlaytestAdmin(data[PLAYTEST][IS_ADMIN]);
-      setPlaytestProfile(data[PLAYTEST].profile);
-      if (!data[PLAYTEST][IS_PLAYTESTER] && !data[PLAYTEST][IS_ADMIN]) setPlaytestMode(false);
+      setIsPlaytester(data[PLAYTEST]?.[IS_PLAYTESTER] ?? false);
+      setIsPlaytestAdmin(data[PLAYTEST]?.[IS_ADMIN] ?? false);
+      setPlaytestProfile(data[PLAYTEST]?.profile);
+      if (!data[PLAYTEST]?.[IS_PLAYTESTER] && !data[PLAYTEST]?.[IS_ADMIN]) setPlaytestMode(false);
       const {
         [IS_FROZEN]: isFrozen,
         [CRYPT]: crypt,


### PR DESCRIPTION
Fixes TypeError: Cannot read properties of undefined (reading 'is_playtester') that crashes the app when logging in.

The playtest field on the user response was accessed without null-safety in AppContext.jsx, so if it's ever missing or the request fails, the app crashes with an unrecoverable error.
 
<img width="1154" height="196" alt="Screenshot 2026-02-13 at 13 37 27" src="https://github.com/user-attachments/assets/6fdb13f9-1570-4fa4-a9dd-8ae562baf229" />
